### PR TITLE
feat: Add RustDesk app to the apps.json

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -9361,5 +9361,32 @@
       "https://raw.githubusercontent.com/jksalcedo/librefind/main/metadata/en-US/images/phoneScreenshots/profile.jpg"
     ],
     "releaseKeyword": "apk"
+  },
+  {
+    "id": "rustdesk-android",
+    "name": "RustDesk",
+    "description": "Open-source remote desktop software. RustDesk is a full-featured open source remote control alternative for self-hosting and security with no configuration required.",
+    "icon": "https://avatars.githubusercontent.com/u/71636191?v=4",
+    "version": "1.4.5",
+    "latestVersion": "1.4.5",
+    "downloadUrl": "https://github.com/rustdesk/rustdesk/releases/download/1.4.5/rustdesk-1.4.5-aarch64-signed.apk",
+    "repoUrl": "https://github.com/rustdesk/rustdesk",
+    "githubRepo": "rustdesk/rustdesk",
+    "gitlabRepo": "",
+    "gitlabDomain": "",
+    "packageName": "com.carriez.rustdesk",
+    "category": "Utility",
+    "platform": "Android",
+    "size": "Varies",
+    "author": "RustDesk",
+    "officialSite": "https://rustdesk.com",
+    "screenshots": [
+      "https://f-droid.org/repo/com.carriez.flutter_hbb/en-US/phoneScreenshots/1.png",
+      "https://f-droid.org/repo/com.carriez.flutter_hbb/en-US/phoneScreenshots/2.png",
+      "https://f-droid.org/repo/com.carriez.flutter_hbb/en-US/phoneScreenshots/3.png",
+      "https://f-droid.org/repo/com.carriez.flutter_hbb/en-US/phoneScreenshots/4.png",
+      "https://f-droid.org/repo/com.carriez.flutter_hbb/en-US/phoneScreenshots/5.png"
+    ],
+    "releaseKeyword": "aarch64-signed.apk"
   }
 ]

--- a/apps.json
+++ b/apps.json
@@ -9369,7 +9369,7 @@
     "icon": "https://avatars.githubusercontent.com/u/71636191?v=4",
     "version": "1.4.5",
     "latestVersion": "1.4.5",
-    "downloadUrl": "https://github.com/rustdesk/rustdesk/releases/download/1.4.5/rustdesk-1.4.5-aarch64-signed.apk",
+    "downloadUrl": "https://github.com/rustdesk/rustdesk/releases/download/1.4.5/rustdesk-1.4.5-universal-signed.apk",
     "repoUrl": "https://github.com/rustdesk/rustdesk",
     "githubRepo": "rustdesk/rustdesk",
     "gitlabRepo": "",


### PR DESCRIPTION
This pull request adds a new Android application entry to the `apps.json` file. The new entry is for RustDesk, an open-source remote desktop software, including all relevant metadata such as version, download URL, repository information, and screenshots.

New app addition:

* Added a new entry for the RustDesk Android app (`rustdesk-android`) to `apps.json`, providing details like name, description, version, download link, repository URLs, package name, category, platform, author, official site, and screenshots.